### PR TITLE
Build and Package Scripts

### DIFF
--- a/examples/package.json
+++ b/examples/package.json
@@ -3,18 +3,21 @@
   "version": "1.0.0",
   "license": "UNLICENSED",
   "author": "FanConnect",
-  "workspaces": [
-    "dad-jokes-app",
-    "boilerplate-app"
-  ],
   "scripts": {
-    "start": "parcel ${INIT_CWD}/src/index.html --dist-dir ${INIT_CWD}/dist",
-    "zip": "cd ${INIT_CWD} && zip ${INIT_CWD}/dist/$(basename ${INIT_CWD}).zip -x '*.zip' -j -r ${INIT_CWD}/dist"
+    "start": "parcel ${INIT_CWD}/src/index.html",
+    "package": "cd ${INIT_CWD} && yarn build && yarn zip",
+    "build": "parcel build ${INIT_CWD}/src/index.html --dist-dir ${INIT_CWD}/dist",
+    "zip": "cd ${INIT_CWD} && zip ${INIT_CWD}/$(basename ${INIT_CWD}).zip -x '*.zip' -j -r ${INIT_CWD}/dist"
   },
   "devDependencies": {
     "@parcel/core": "2.8.2",
     "@parcel/transformer-sass": "2.8.2",
     "parcel": "2.8.2",
     "parcel-reporter-clean-dist": "^1.0.4"
+  },
+  "targets": {
+    "default": {
+      "publicUrl": "./"
+    }
   }
 }


### PR DESCRIPTION
This adds a `build` script which uses parcel's build command, and changes the `publicUrl` setting to relative urls instead of absolute (Neo needs these to be relative). This also adds a `package` script which runs `build` and then `zip`.